### PR TITLE
shallowRefの実装

### DIFF
--- a/examples/playground/src/main.ts
+++ b/examples/playground/src/main.ts
@@ -1,8 +1,8 @@
-import { createApp, h, ref } from 'chibivue'
+import { createApp, h, shallowRef } from 'chibivue'
 
 const app = createApp({
   setup() {
-    const state = ref({ count: 0 })
+    const state = shallowRef({ count: 0 })
 
     return () =>
       h('div', {}, [
@@ -23,11 +23,11 @@ const app = createApp({
           'button',
           {
             onClick: () => {
-              // 描画が更新される
+              // 描画は更新されない（が、内部の値はインクリメントされる）
               state.value.count++
             },
           },
-          ['not trigger ... ?']
+          ['not trigger ...']
         ),
       ])
   },

--- a/examples/playground/src/main.ts
+++ b/examples/playground/src/main.ts
@@ -14,6 +14,7 @@ const app = createApp({
             onClick: () => {
               // 描画が更新される
               state.value = { count: state.value.count + 1 }
+              console.log('valueを更新：', state.value.count)
             },
           },
           ['increment']
@@ -25,6 +26,7 @@ const app = createApp({
             onClick: () => {
               // 描画は更新されない（が、内部の値はインクリメントされる）
               state.value.count++
+              console.log('value.countを更新：', state.value.count)
             },
           },
           ['not trigger ...']

--- a/examples/playground/src/main.ts
+++ b/examples/playground/src/main.ts
@@ -2,12 +2,33 @@ import { createApp, h, ref } from 'chibivue'
 
 const app = createApp({
   setup() {
-    const count = ref(0)
+    const state = ref({ count: 0 })
 
     return () =>
       h('div', {}, [
-        h('p', {}, [`count: ${count.value}`]),
-        h('button', { onClick: () => count.value++ }, ['Increment']),
+        h('p', {}, [`count: ${state.value.count}`]),
+
+        h(
+          'button',
+          {
+            onClick: () => {
+              // 描画が更新される
+              state.value = { count: state.value.count + 1 }
+            },
+          },
+          ['increment']
+        ),
+
+        h(
+          'button',
+          {
+            onClick: () => {
+              // 描画が更新される
+              state.value.count++
+            },
+          },
+          ['not trigger ... ?']
+        ),
       ])
   },
 })

--- a/packages/reactivity/index.ts
+++ b/packages/reactivity/index.ts
@@ -1,3 +1,3 @@
-export { ref } from './ref'
+export { ref, shallowRef } from './ref'
 export { reactive } from './reactive'
 export { ReactiveEffect } from './effect'

--- a/packages/reactivity/ref.ts
+++ b/packages/reactivity/ref.ts
@@ -41,6 +41,22 @@ export function ref(value?: unknown) {
 }
 
 //
+// shallow ref
+//
+
+declare const ShallowRefMarker: unique symbol
+export type ShallowRef<T = any> = Ref<T> & { [ShallowRefMarker]?: true }
+
+export function shallowRef<T extends object>(
+  value: T
+): T extends Ref ? T : ShallowRef<T>
+export function shallowRef<T>(value: T): ShallowRef<T>
+export function shallowRef<T = any>(): ShallowRef<T | undefined>
+export function shallowRef(value?: unknown) {
+  return createRef(value, true)
+}
+
+//
 // common
 //
 

--- a/packages/reactivity/ref.ts
+++ b/packages/reactivity/ref.ts
@@ -30,17 +30,25 @@ export function isRef(r: any): r is Ref {
   return !!(r && r.__v_isRef === true)
 }
 
+//
+// ref
+//
+
 export function ref<T = any>(): Ref<T | undefined>
 export function ref<T = any>(value: T): Ref<T>
 export function ref(value?: unknown) {
-  return createRef(value)
+  return createRef(value, false)
 }
 
-function createRef(rawValue: unknown) {
+//
+// common
+//
+
+function createRef(rawValue: unknown, shallow: boolean) {
   if (isRef(rawValue)) {
     return rawValue
   }
-  return new RefImpl(rawValue)
+  return new RefImpl(rawValue, shallow)
 }
 
 // 現在のエフェクトをdepに登録する（depが存在しない場合は新たに作成する）
@@ -58,9 +66,13 @@ class RefImpl<T> {
   public dep?: Dep = undefined
   public readonly __v_isRef = true
 
-  constructor(value: T) {
-    // ref の値としてオブジェクトが代入された場合、そのオブジェクトを reactive に変換する
-    this._value = toReactive(value)
+  constructor(
+    value: T,
+    public readonly __v_isShallow: boolean
+  ) {
+    // ref： 深いリアクティブ（オブジェクトが代入された場合、そのオブジェクトを reactive に変換する）
+    // shallow ref： 浅いリアクティブ（reactive への変換をスキップ）
+    this._value = __v_isShallow ? value : toReactive(value)
   }
 
   // Refの値にアクセスされたら、現在のエフェクトをdepに登録する
@@ -71,7 +83,7 @@ class RefImpl<T> {
 
   // Refの値が変更されたら、depに登録されたエフェクトを実行する
   set value(newVal) {
-    this._value = toReactive(newVal)
+    this._value = this.__v_isShallow ? newVal : toReactive(newVal)
     triggerRefValue(this)
   }
 }


### PR DESCRIPTION
https://book.chibivue.land/ja/30-basic-reactivity-system/010-ref-api.html#shallowref

```ts
import { createApp, h, shallowRef } from 'chibivue'

const app = createApp({
  setup() {
    const state = shallowRef({ count: 0 })

    return () =>
      h('div', {}, [
        h('p', {}, [`count: ${state.value.count}`]),

        h(
          'button',
          {
            onClick: () => {
              // 描画が更新される
              state.value = { count: state.value.count + 1 }
              console.log('valueを更新：', state.value.count)
            },
          },
          ['increment']
        ),

        h(
          'button',
          {
            onClick: () => {
              // 描画は更新されない（が、内部の値はインクリメントされる）
              state.value.count++
              console.log('value.countを更新：', state.value.count)
            },
          },
          ['not trigger ...']
        ),
      ])
  },
})

app.mount('#app')
```

<img width="847" alt="スクリーンショット 2024-11-26 15 30 27" src="https://github.com/user-attachments/assets/e3fc2032-2dbb-4e14-bc67-b35aa7dec487">
<img width="847" alt="スクリーンショット 2024-11-26 15 31 13" src="https://github.com/user-attachments/assets/4f603a24-bb61-42c2-aa9b-79419e8e4ff9">
<img width="847" alt="スクリーンショット 2024-11-26 15 31 18" src="https://github.com/user-attachments/assets/664e5c2f-e5b7-4e68-939d-f95260feb467">


