### PR TITLE
triggerRefの実装

### DIFF
--- a/examples/playground/src/main.ts
+++ b/examples/playground/src/main.ts
@@ -1,8 +1,11 @@
-import { createApp, h, shallowRef } from 'chibivue'
+import { createApp, h, shallowRef, triggerRef } from 'chibivue'
 
 const app = createApp({
   setup() {
     const state = shallowRef({ count: 0 })
+    const forceUpdate = () => {
+      triggerRef(state)
+    }
 
     return () =>
       h('div', {}, [
@@ -30,6 +33,18 @@ const app = createApp({
             },
           },
           ['not trigger ...']
+        ),
+
+        h(
+          'button',
+          {
+            onClick: () => {
+              // 描画が今の state.value.count が持つ値に更新される
+              forceUpdate()
+              console.log('force update !')
+            },
+          },
+          ['force update !']
         ),
       ])
   },

--- a/packages/reactivity/index.ts
+++ b/packages/reactivity/index.ts
@@ -1,3 +1,3 @@
-export { ref, shallowRef } from './ref'
+export { ref, shallowRef, triggerRef } from './ref'
 export { reactive } from './reactive'
 export { ReactiveEffect } from './effect'

--- a/packages/reactivity/ref.ts
+++ b/packages/reactivity/ref.ts
@@ -103,3 +103,11 @@ class RefImpl<T> {
     triggerRefValue(this)
   }
 }
+
+//
+// trigger ref
+//
+
+export function triggerRef(ref: Ref) {
+  triggerRefValue(ref)
+}


### PR DESCRIPTION
https://book.chibivue.land/ja/30-basic-reactivity-system/010-ref-api.html#triggerref

```ts
import { createApp, h, shallowRef, triggerRef } from 'chibivue'

const app = createApp({
  setup() {
    const state = shallowRef({ count: 0 })
    const forceUpdate = () => {
      triggerRef(state)
    }

    return () =>
      h('div', {}, [
        h('p', {}, [`count: ${state.value.count}`]),

        h(
          'button',
          {
            onClick: () => {
              // 描画が更新される
              state.value = { count: state.value.count + 1 }
              console.log('valueを更新：', state.value.count)
            },
          },
          ['increment']
        ),

        h(
          'button',
          {
            onClick: () => {
              // 描画は更新されない（が、内部の値はインクリメントされる）
              state.value.count++
              console.log('value.countを更新：', state.value.count)
            },
          },
          ['not trigger ...']
        ),

        h(
          'button',
          {
            onClick: () => {
              // 描画が今の state.value.count が持つ値に更新される
              forceUpdate()
              console.log('force update !')
            },
          },
          ['force update !']
        ),
      ])
  },
})

app.mount('#app')
```

<img width="847" alt="スクリーンショット 2024-11-26 15 39 51" src="https://github.com/user-attachments/assets/e4dad49b-a99a-4bb5-9165-6edade7e29c1">
<img width="847" alt="スクリーンショット 2024-11-26 15 39 56" src="https://github.com/user-attachments/assets/e105762d-1b87-4890-a2fc-98f482a3bac7">
<img width="847" alt="スクリーンショット 2024-11-26 15 40 04" src="https://github.com/user-attachments/assets/6b52b443-c1a7-40cf-8e76-55be1a22cf3c">

