### PR TITLE
toRefの実装

### DIFF
--- a/examples/playground/src/main.ts
+++ b/examples/playground/src/main.ts
@@ -1,51 +1,16 @@
-import { createApp, h, shallowRef, triggerRef } from 'chibivue'
+import { createApp, h, reactive, toRef } from 'chibivue'
 
 const app = createApp({
   setup() {
-    const state = shallowRef({ count: 0 })
-    const forceUpdate = () => {
-      triggerRef(state)
-    }
+    const state = reactive({ count: 0 })
+    const stateCountRef = toRef(state, 'count')
 
     return () =>
       h('div', {}, [
-        h('p', {}, [`count: ${state.value.count}`]),
-
-        h(
-          'button',
-          {
-            onClick: () => {
-              // 描画が更新される
-              state.value = { count: state.value.count + 1 }
-              console.log('valueを更新：', state.value.count)
-            },
-          },
-          ['increment']
-        ),
-
-        h(
-          'button',
-          {
-            onClick: () => {
-              // 描画は更新されない（が、内部の値はインクリメントされる）
-              state.value.count++
-              console.log('value.countを更新：', state.value.count)
-            },
-          },
-          ['not trigger ...']
-        ),
-
-        h(
-          'button',
-          {
-            onClick: () => {
-              // 描画が今の state.value.count が持つ値に更新される
-              forceUpdate()
-              console.log('force update !')
-            },
-          },
-          ['force update !']
-        ),
+        h('p', {}, [`state.count: ${state.count}`]),
+        h('p', {}, [`stateCountRef.value: ${stateCountRef.value}`]),
+        h('button', { onClick: () => state.count++ }, ['updateState']),
+        h('button', { onClick: () => stateCountRef.value++ }, ['updateRef']),
       ])
   },
 })

--- a/packages/reactivity/effect.ts
+++ b/packages/reactivity/effect.ts
@@ -100,3 +100,7 @@ function triggerEffect(effect: ReactiveEffect) {
     effect.run()
   }
 }
+
+export function getDepFromReactive(object: any, key: string | number | symbol) {
+  return targetMap.get(object)?.get(key)
+}

--- a/packages/reactivity/index.ts
+++ b/packages/reactivity/index.ts
@@ -1,3 +1,3 @@
-export { ref, shallowRef, triggerRef } from './ref'
+export { ref, shallowRef, triggerRef, toRef } from './ref'
 export { reactive } from './reactive'
 export { ReactiveEffect } from './effect'

--- a/packages/reactivity/ref.ts
+++ b/packages/reactivity/ref.ts
@@ -1,3 +1,4 @@
+import { IfAny } from '../shared'
 import { createDep, Dep } from './dep'
 import { getDepFromReactive, trackEffects, triggerEffects } from './effect'
 import { toReactive } from './reactive'
@@ -116,6 +117,17 @@ export function triggerRef(ref: Ref) {
 // to ref
 //
 
+export type ToRef<T> = IfAny<T, Ref<T>, [T] extends [Ref] ? T : Ref<T>>
+
+export function toRef<T extends object, K extends keyof T>(
+  object: T,
+  key: K
+): ToRef<T[K]>
+export function toRef<T extends object, K extends keyof T>(
+  object: T,
+  key: K,
+  defaultValue: T[K]
+): ToRef<Exclude<T[K], undefined>>
 export function toRef(
   source: Record<string, any>,
   key?: string,

--- a/packages/reactivity/ref.ts
+++ b/packages/reactivity/ref.ts
@@ -116,6 +116,10 @@ export function triggerRef(ref: Ref) {
 //
 // to ref
 //
+// toRef によって作られた ref は元の reactive オブジェクトと同期される
+// - この ref に変更を加えると元の reactive オブジェクトも更新される
+// - 元の reactive オブジェクトに変更があるとこの ref も更新される
+//
 
 export type ToRef<T> = IfAny<T, Ref<T>, [T] extends [Ref] ? T : Ref<T>>
 
@@ -129,8 +133,8 @@ export function toRef<T extends object, K extends keyof T>(
   defaultValue: T[K]
 ): ToRef<Exclude<T[K], undefined>>
 export function toRef(
-  source: Record<string, any>,
-  key?: string,
+  source: Record<string, any>, // reactive オブジェクト
+  key?: string, // refに変換したいプロパティ
   defaultValue?: unknown
 ): Ref {
   return propertyToRef(source, key!, defaultValue)
@@ -154,11 +158,13 @@ class ObjectRefImpl<T extends object, K extends keyof T> {
   ) {}
 
   get value() {
+    // 元のリアクティブオブジェクトのプロパティを直接取り出す
     const val = this._object[this._key]
     return val === undefined ? (this._defaultValue as T[K]) : val
   }
 
   set value(newVal) {
+    // 元のリアクティブオブジェクトのプロパティを直接更新
     this._object[this._key] = newVal
   }
 

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -1,1 +1,2 @@
 export * from './general'
+export * from './typeUtils'

--- a/packages/shared/typeUtils.ts
+++ b/packages/shared/typeUtils.ts
@@ -1,0 +1,1 @@
+export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N


### PR DESCRIPTION
https://book.chibivue.land/ja/30-basic-reactivity-system/010-ref-api.html#toref

```ts
import { createApp, h, reactive, toRef } from 'chibivue'

const app = createApp({
  setup() {
    const state = reactive({ count: 0 })
    const stateCountRef = toRef(state, 'count')

    return () =>
      h('div', {}, [
        h('p', {}, [`state.count: ${state.count}`]),
        h('p', {}, [`stateCountRef.value: ${stateCountRef.value}`]),
        h('button', { onClick: () => state.count++ }, ['updateState']),
        h('button', { onClick: () => stateCountRef.value++ }, ['updateRef']),
      ])
  },
})

app.mount('#app')
```

どっちのボタンを押しても、値は一緒に更新される

![chibivue](https://github.com/user-attachments/assets/06034e95-9526-428b-83fc-067e38bac617)
![chibivue · 8 47am · 11-27](https://github.com/user-attachments/assets/7aef746f-11db-43ff-b007-c2e93bdf3fee)

